### PR TITLE
Fix JSON in one of the examples

### DIFF
--- a/spec/model/examples/euro_champs.json
+++ b/spec/model/examples/euro_champs.json
@@ -1,59 +1,45 @@
-// 
-// Example of description of a Decathlon event at championship
-// 
-
 {
-    '@context' : 'https://w3c.github.io/opentrack-cg/contexts/opentrack.jsonld', 
-    '@id' : 'http://example.com/competition:0103441',
-    '@type' :  'Competition',
-    'name' : '2016 European Athletics Championships',
-    'alternateName' : 'Amsterdam Euro 2016',        
-    'url' : 'http://www.european-athletics.org/competitions/european-athletics-championships/2016/events/',
-    'image' : 'https://upload.wikimedia.org/wikipedia/en/thumb/d/df/Amsterdam2016logo.png',
-    'location' :
-        {
-            '@id' : 'http://example.com/venue:AMS_OS',
-            '@type' : 'Venue',                
-            'name' : 'Olympic Stadium Amsterdam',
-            'geo' : 
-                {
-                    'latitude' : '52.343417',
-                    'longitude' : '4.854192'
-                },
-            'map' : 'http://example.org/map',
-            'address' : 
-                {
-                    'streetAddress' : 'Olympisch Stadion 2',
-                    'addressLocality' : 'Amsterdam',
-                    'postalCode' : '1076 DE',
-                    'addressCountry' : 'country:NL'
-                }
+    "@context": "https://w3c.github.io/opentrack-cg/contexts/opentrack.jsonld",
+    "@id": "http://example.com/competition:0103441",
+    "@type": "Competition",
+    "name": "2016 European Athletics Championships",
+    "alternateName": "Amsterdam Euro 2016",
+    "url": "http://www.european-athletics.org/competitions/european-athletics-championships/2016/events/",
+    "image": "https://upload.wikimedia.org/wikipedia/en/thumb/d/df/Amsterdam2016logo.png",
+    "location": {
+        "@id": "http://example.com/venue:AMS_OS",
+        "@type": "Venue",
+        "name": "Olympic Stadium Amsterdam",
+        "geo": {
+            "latitude": "52.343417",
+            "longitude": "4.854192"
         },
-    'startDate' : '2016-06-06',  
-    'endDate' : '2016-06-10',    
-    'status' : 'status:completed',
-    'organizer' : 'http://example.com/federation:EA' ,
-    'event' :     // List of events within the overall competition
-        [
-            'http://example.com/event:EURO2016_100_metres_Men',
-            'http://example.com/event:EURO2016_100_metres_Women',
-            'http://example.com/event:EURO2016_200_metres_Men',
-            'http://example.com/event:EURO2016_200_metres_Women',
-            'http://example.com/event:EURO2016_400_metres_Men',
-            'http://example.com/event:EURO2016_400_metres_Women',
-            // …
-            'http://example.com/event:EURO2016_400x100_metres_Men',
-            'http://example.com/event:EURO2016_400x100_metres_Women',
-            'http://example.com/event:EURO2016_LJ_Men',
-            'http://example.com/event:EURO2016_LJ_Women',
-            'http://example.com/event:EURO2016_Marathon_Men',
-            'http://example.com/event:EURO2016_Marathon_Women',
-            'http://example.com/event:EURO2016_Heptathlon',
-            'http://example.com/event:EURO2016_Decathlon'
-        ]
+        "map": "http://example.org/map",
+        "address": {
+            "streetAddress": "Olympisch Stadion 2",
+            "addressLocality": "Amsterdam",
+            "postalCode": "1076 DE",
+            "addressCountry": "country:NL"
+        }
+    },
+    "startDate": "2016-06-06",
+    "endDate": "2016-06-10",
+    "status": "status:completed",
+    "organizer": "http://example.com/federation:EA",
+    "event": [
+        "http://example.com/event:EURO2016_100_metres_Men",
+        "http://example.com/event:EURO2016_100_metres_Women",
+        "http://example.com/event:EURO2016_200_metres_Men",
+        "http://example.com/event:EURO2016_200_metres_Women",
+        "http://example.com/event:EURO2016_400_metres_Men",
+        "http://example.com/event:EURO2016_400_metres_Women",
+        "http://example.com/event:EURO2016_400x100_metres_Men",
+        "http://example.com/event:EURO2016_400x100_metres_Women",
+        "http://example.com/event:EURO2016_LJ_Men",
+        "http://example.com/event:EURO2016_LJ_Women",
+        "http://example.com/event:EURO2016_Marathon_Men",
+        "http://example.com/event:EURO2016_Marathon_Women",
+        "http://example.com/event:EURO2016_Heptathlon",
+        "http://example.com/event:EURO2016_Decathlon"
+    ]
 }
-
-// Events are described in other files: 
-//  - euro_champs_heptathlon.json
-//  - euro_champs_100m.json
-//  - euro_champs_LJ.json


### PR DESCRIPTION
The 6 files under [`/spec/model/examples/`](https://github.com/w3c/opentrack-cg/tree/master/spec/model/examples) are not valid JSON.

While these are just examples, and not intended to be correct, breaking [the JSON spec](http://json.org/) causes a few minor inconveniences:

* Syntax highlighting does not work on GitHub ([example](https://github.com/w3c/opentrack-cg/blob/master/spec/model/examples/competitors.json)).
* Files are not parsed nor displayed as JSON on browsers ([example](https://w3c.github.io/opentrack-cg/spec/model/examples/euro_champs_4x400.json)).
* Some editors that detect JSON errors complain and highlight problems.
* As they are now, it's not possible to start using these examples programmatically (for early experiments, etc).

This PR &ldquo;fixes&rdquo; one of these examples. Validity can be checked eg using [an online JSON validator/editor](http://jsoneditoronline.org/). Most browsers may display the file very differently, and editors won't complain. See [the file on the browser](https://raw.githubusercontent.com/w3c/opentrack-cg/tripu/fix-json/spec/model/examples/euro_champs.json) (if your browser has [a JSON extension](https://chrome.google.com/webstore/detail/json-viewer/aimiinbnnkboelefkjlenlgimcabobli), it will let you collapse/expand entire sections, highlight syntax, render URIs as hyperlinks, etc).

NB: inline comments that were deleted here will have to be put somewhere else (eg, a new text file just for this?).

@espinr, if you're happy about this change, I'll do the same with the other 5 files.