### PR TITLE
Correcting code for loss of contact

### DIFF
--- a/spec/model/index.html
+++ b/spec/model/index.html
@@ -2081,7 +2081,7 @@ EEA also uses other feature codes that will be taken into account.
 | `feature:qR` | Advanced to next round by Referee |
 | `feature:qJ` | Advanced to next round by Jury of Appeal |
 | `feature:>` | Bent knee (Race walking) |
-| `feature:%3E` | Loss of contact (Race walking) |
+| `feature:~` | Loss of contact (Race walking) |
 | `feature:yC` | yellow Card |
 | `feature:yRC` | Second yellow Card |
 | `feature:RC` | Red Card |


### PR DESCRIPTION
This is ~, whereas %3E is the ASCII code for > (bent knee)